### PR TITLE
[Feature] Added video comments

### DIFF
--- a/backend/app/app/settings.py
+++ b/backend/app/app/settings.py
@@ -53,6 +53,7 @@ INSTALLED_APPS = [
     "corsheaders",
     "drf_spectacular",
     "rest_framework",
+    "comment",
     "core",
     "user",
     "video",

--- a/backend/app/app/urls.py
+++ b/backend/app/app/urls.py
@@ -20,6 +20,7 @@ from django.urls import path, include
 
 urlpatterns = [
     path("admin/", admin.site.urls, name="admin-site"),
+    path("api/comments/", include("comment.urls"), name="comment-resource"),
     path("api/users/", include("user.urls"), name="user-resource"),
     path("api/videos/", include("video.urls"), name="video-resource"),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/backend/app/comment/apps.py
+++ b/backend/app/comment/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class CommentConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "comment"

--- a/backend/app/comment/serializers.py
+++ b/backend/app/comment/serializers.py
@@ -1,0 +1,18 @@
+from rest_framework import serializers
+from core import models
+
+
+class CommentSerializer(serializers.ModelSerializer):
+    created_at = serializers.SerializerMethodField()
+    created_by = serializers.SerializerMethodField()
+
+    class Meta:
+        model = models.Comment
+        fields = "__all__"
+        read_only_fields = ("id", "created_at", "created_by", "likes")
+
+    def get_created_at(self, obj):
+        return obj.created_at.strftime("%Y-%m-%d %H:%M:%S")
+
+    def get_created_by(self, obj):
+        return obj.created_by.username

--- a/backend/app/comment/tests.py
+++ b/backend/app/comment/tests.py
@@ -1,0 +1,95 @@
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from rest_framework.test import APITestCase
+from rest_framework import status
+from core import models
+
+
+class CommentPublicAPITests(APITestCase):
+    """Test the publicly available comment API"""
+
+    def setUp(self):
+        self.user = get_user_model().objects.create(
+            first_name="Test",
+            last_name="User",
+            username="testuser",
+            email="testuser@example.com",
+            password="testpass",
+        )
+        self.video = models.Video.objects.create(
+            title="Test Video",
+            description="Test Video Description",
+            thumbnail="wii.jpg",
+            file="wii.mp4",
+            created_by=self.user,
+        )
+        self.comment = models.Comment.objects.create(
+            text="Test comment", created_by=self.user, video=self.video
+        )
+
+    def test_retrieve_comment(self):
+        """Test retrieving a comment"""
+        url = reverse("comment:detail", args=[self.comment.id])
+        res = self.client.get(url)
+
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data["text"], self.comment.text)
+
+
+class CommentPrivateAPITests(APITestCase):
+    """Test the private comment API"""
+
+    def setUp(self):
+        self.user = get_user_model().objects.create(
+            first_name="Test",
+            last_name="User",
+            username="testuser",
+            email="testuser@example.com",
+            password="testpass",
+        )
+        self.video = models.Video.objects.create(
+            title="Test Video",
+            description="Test Video Description",
+            thumbnail="wii.jpg",
+            file="wii.mp4",
+            created_by=self.user,
+        )
+        self.comment = models.Comment.objects.create(
+            text="Test comment", created_by=self.user, video=self.video
+        )
+        self.client.force_authenticate(user=self.user)
+
+    def test_update_comment(self):
+        """Test updating a comment"""
+        url = reverse("comment:detail", args=[self.comment.id])
+        payload = {"text": "Updated comment"}
+        self.client.force_authenticate(user=self.user)
+        res = self.client.patch(url, payload)
+
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data["text"], payload["text"])
+
+    def test_update_comment_unauthorized(self):
+        """Test updating a comment as unauthorized user"""
+        url = reverse("comment:detail", args=[self.comment.id])
+        payload = {"text": "Updated comment"}
+        self.client.force_authenticate(user=None)
+        res = self.client.patch(url, payload)
+
+        self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_delete_comment(self):
+        """Test deleting a comment"""
+        url = reverse("comment:detail", args=[self.comment.id])
+        self.client.force_authenticate(user=self.user)
+        res = self.client.delete(url)
+
+        self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_delete_comment_unauthorized(self):
+        """Test deleting a comment as unauthorized user"""
+        url = reverse("comment:detail", args=[self.comment.id])
+        self.client.force_authenticate(user=None)
+        res = self.client.delete(url)
+
+        self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/backend/app/comment/urls.py
+++ b/backend/app/comment/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+from comment import views
+
+app_name = "comment"
+
+urlpatterns = [
+    path("<int:id>/", views.CommentDetailView.as_view(), name="detail"),
+]

--- a/backend/app/comment/views.py
+++ b/backend/app/comment/views.py
@@ -1,0 +1,132 @@
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from comment import serializers
+from core import models
+
+
+class CommentDetailView(APIView):
+    """
+    Comment view for retrieving, updating and deleting a comment
+    Allowed methods: GET, PATCH, DELETE
+    """
+
+    serializer_class = serializers.CommentSerializer
+    permission_classes = (IsAuthenticatedOrReadOnly,)
+    queryset = models.Comment.objects
+
+    def get(self, request, id, format=None):
+        """Retrieve a comment"""
+
+        try:
+            comment = self.queryset.get(id=id)
+            serializer = self.serializer_class(comment, many=False)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        except models.Comment.DoesNotExist:
+            """Return 404 if comment not found"""
+
+            response = {
+                "status": "404",
+                "title": "Not Found",
+                "detail": "Comment not found",
+            }
+            return Response(response, status=status.HTTP_404_NOT_FOUND)
+        except Exception:
+            """Return 500 if server error"""
+
+            response = {
+                "status": "500",
+                "title": "Internal Server Error",
+                "detail": "Server error",
+            }
+            return Response(
+                response, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
+    def patch(self, request, id, format=None):
+        """Update a comment"""
+
+        try:
+            comment = self.queryset.get(id=id)
+            user = request.user
+
+            if comment.created_by != user:
+                """Return 403 if user is not comment creator"""
+
+                response = {
+                    "status": "403",
+                    "title": "Forbidden",
+                    "detail": "You are not the comment creator",
+                }
+                return Response(response, status=status.HTTP_403_FORBIDDEN)
+
+            serializer = self.serializer_class(
+                comment, data=request.data, partial=True
+            )
+            if serializer.is_valid():
+                serializer.save()
+                return Response(serializer.data, status=status.HTTP_200_OK)
+            return Response(
+                serializer.errors, status=status.HTTP_400_BAD_REQUEST
+            )
+        except models.Comment.DoesNotExist:
+            """Return 404 if comment not found"""
+
+            response = {
+                "status": "404",
+                "title": "Not Found",
+                "detail": "Comment not found",
+            }
+            return Response(response, status=status.HTTP_404_NOT_FOUND)
+        except Exception:
+            """Return 500 if server error"""
+
+            response = {
+                "status": "500",
+                "title": "Internal Server Error",
+                "detail": "Server error",
+            }
+            return Response(
+                response, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
+    def delete(self, request, id, format=None):
+        """Delete a comment"""
+
+        try:
+            comment = self.queryset.get(id=id)
+            user = request.user
+
+            if comment.created_by != user:
+                """Return 403 if user is not comment creator"""
+
+                response = {
+                    "status": "403",
+                    "title": "Forbidden",
+                    "detail": "You are not the comment creator",
+                }
+                return Response(response, status=status.HTTP_403_FORBIDDEN)
+
+            comment.delete()
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        except models.Comment.DoesNotExist:
+            """Return 404 if comment not found"""
+
+            response = {
+                "status": "404",
+                "title": "Not Found",
+                "detail": "Comment not found",
+            }
+            return Response(response, status=status.HTTP_404_NOT_FOUND)
+        except Exception:
+            """Return 500 if server error"""
+
+            response = {
+                "status": "500",
+                "title": "Internal Server Error",
+                "detail": "Server error",
+            }
+            return Response(
+                response, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )

--- a/backend/app/video/serializers.py
+++ b/backend/app/video/serializers.py
@@ -41,3 +41,22 @@ class VideoSerializer(serializers.ModelSerializer):
     def get_created_by(self, obj):
         user = obj.created_by
         return user.username
+
+
+class CommentSerializer(serializers.ModelSerializer):
+    """Serializer for video comments"""
+
+    created_at = serializers.SerializerMethodField()
+    created_by = serializers.SerializerMethodField()
+
+    class Meta:
+        model = models.Comment
+        fields = "__all__"
+        read_only_fields = ("id", "created_at", "created_by", "likes")
+
+    def get_created_at(self, obj):
+        return obj.created_at.strftime("%Y-%m-%d %H:%M:%S")
+
+    def get_created_by(self, obj):
+        user = obj.created_by
+        return user.username

--- a/backend/app/video/tests.py
+++ b/backend/app/video/tests.py
@@ -105,3 +105,34 @@ class PrivateVideoApiTests(APITestCase):
         res = self.client.delete(url)
 
         self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_comment_video_success(self):
+        """Test commenting on a video"""
+        url = reverse("video:comment", args=[self.video.id])
+
+        payload = {"text": "Test Comment"}
+
+        res = self.client.post(url, payload, format="json")
+        data = res.data
+
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)
+        self.assertIn("Location", res.headers)
+        self.assertEqual(data["text"], payload["text"])
+        self.assertEqual(data["video"], self.video.id)
+
+    def test_retrieve_comments_success(self):
+        """Test retrieving comments on a video"""
+        models.Comment.objects.create(
+            text="Test Comment 1", video=self.video, created_by=self.user
+        )
+        models.Comment.objects.create(
+            text="Test Comment 2", video=self.video, created_by=self.user
+        )
+
+        url = reverse("video:comment", args=[self.video.id])
+        res = self.client.get(url)
+
+        data = res.data
+
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(data), 2)

--- a/backend/app/video/urls.py
+++ b/backend/app/video/urls.py
@@ -6,4 +6,7 @@ app_name = "video"
 urlpatterns = [
     path("", views.VideoList.as_view(), name="list"),
     path("<int:id>/", views.VideoDetailView.as_view(), name="detail"),
+    path(
+        "<int:id>/comments/", views.CommentListView.as_view(), name="comment"
+    ),
 ]


### PR DESCRIPTION
# Description
Added CRUD operations for comments.

## Endpoints
2 endpoints for CRUD operations.

The user must be the comment owner to update or delete it.
Any user can retrieve comments.

### CRUD
`/api/videos/:id/comments/`
**Supports:** GET, POST
**Auth:** Authenticated or readonly

`/api/comments/id/`
**Suppots:** GET, PATCH, DELETE
**Auth:** Authenticated or readonly

## Changelog
- Added video comments
- Added comment test
