### PR TITLE
[Feature] Added video likes

### DIFF
--- a/backend/app/video/tests.py
+++ b/backend/app/video/tests.py
@@ -136,3 +136,42 @@ class PrivateVideoApiTests(APITestCase):
 
         self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertEqual(len(data), 2)
+
+    def test_like_video_success(self):
+        """Test liking a video"""
+        url = reverse("video:like", args=[self.video.id])
+
+        res = self.client.post(url)
+        self.video.refresh_from_db()
+
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)
+        self.assertNotIn("Location", res.headers)
+        self.assertEqual(self.video.likes, 1)
+
+    def test_retrieve_likes_success(self):
+        """Test retrieving likes count on a video"""
+        models.VideoLike.objects.create(video=self.video, liked_by=self.user)
+        self.video.likes += 1
+        self.video.save()
+
+        url = reverse("video:like", args=[self.video.id])
+        res = self.client.get(url)
+        self.video.refresh_from_db()
+        data = res.data
+
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(data["count"], 1)
+        self.assertEqual(self.video.likes, 1)
+
+    def test_dislike_video_success(self):
+        """Test disliking a video"""
+        models.VideoLike.objects.create(video=self.video, liked_by=self.user)
+        self.video.likes += 1
+        self.video.save()
+
+        url = reverse("video:like", args=[self.video.id])
+        res = self.client.delete(url)
+        self.video.refresh_from_db()
+
+        self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(self.video.likes, 1)

--- a/backend/app/video/urls.py
+++ b/backend/app/video/urls.py
@@ -9,4 +9,5 @@ urlpatterns = [
     path(
         "<int:id>/comments/", views.CommentListView.as_view(), name="comment"
     ),
+    path("<int:id>/likes/", views.LikeListView.as_view(), name="like"),
 ]


### PR DESCRIPTION
# Description
Added likes to videos.

- A user must be authenticated in order to like a video.
- A user can like many videos, but cannot like the same video twice.
- A user can dislike a video, but cannot dislike a video the user hasn't liked.

## Endpoints
`/api/videos/:id/likes/`
Supports: GET, POST, DELETE
Auth: Authenticated or readonly

## Changelog
- Added video likes endpoint
- Added video likes tests
