### PR TITLE
[Bugfix] Video dislike not working

### DIFF
--- a/backend/app/video/serializers.py
+++ b/backend/app/video/serializers.py
@@ -86,10 +86,10 @@ class LikeSerializer(serializers.ModelSerializer):
 
         return super().create(validated_data)
 
-    def delete(self, validated_data):
+    def delete(self, instance):
         """Deletes a like and updates the video likes count"""
-        video = validated_data["video"]
+        video = instance.video
         video.likes -= 1
         video.save()
 
-        return super().delete(validated_data)
+        instance.delete()

--- a/backend/app/video/tests.py
+++ b/backend/app/video/tests.py
@@ -174,4 +174,4 @@ class PrivateVideoApiTests(APITestCase):
         self.video.refresh_from_db()
 
         self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertEqual(self.video.likes, 1)
+        self.assertEqual(self.video.likes, 0)

--- a/backend/app/video/views.py
+++ b/backend/app/video/views.py
@@ -371,9 +371,8 @@ class LikeListView(APIView):
 
         try:
             video = models.Video.objects.get(id=id)
-            likes = self.queryset.filter(video=video)
-            count = likes.count()
-            response = {"count": count}
+            likes = video.likes
+            response = {"count": likes}
             return Response(response, status=status.HTTP_200_OK)
         except models.Video.DoesNotExist:
             response = {
@@ -441,10 +440,9 @@ class LikeListView(APIView):
                 "detail": "The video was not found",
             }
             return Response(response, status=status.HTTP_404_NOT_FOUND)
-        except Exception as e:
+        except Exception:
             """Return a 500 error if there was an error liking the video"""
 
-            print(e)
             response = {
                 "status": "500",
                 "title": "Internal Server Error",
@@ -476,7 +474,8 @@ class LikeListView(APIView):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
-            like.delete()
+            serializer = self.serializer_class()
+            serializer.delete(like.first())
 
             return Response(status=status.HTTP_204_NO_CONTENT)
         except models.Video.DoesNotExist:


### PR DESCRIPTION
# Description
Video dislike was not working correctly. Serializer was never used.

## Solution
Using `LikeSerializer` to delete the video.
